### PR TITLE
Delete semicolon from from array_push macro

### DIFF
--- a/array.h
+++ b/array.h
@@ -5,7 +5,7 @@
     do {                                                                      \
         (array) = array_hold((array), 1, sizeof(*(array)));                   \
         (array)[array_length(array) - 1] = (value);                           \
-    } while (0);
+    } while (0)
 
 void* array_hold(void* array, int count, int item_size);
 int array_length(void* array);


### PR DESCRIPTION
There is a semicolon in the end of the `do ... while (0)` that is not needed. 